### PR TITLE
(#11) Throw error with details for unmatched keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,20 @@
 const isObj = require('is-obj');
 
 
-const deepEqSkip = function(data, expectedData, skipKeys = []) {
+const deepEqSkip = function (data, expectedData, skipKeys = []) {
 
   // Validate data type of both the data
-  if (typeof(data) !== typeof(expectedData)) {
-    return false;
+  if (typeof (data) !== typeof (expectedData)) {
+    throw new Error(`Expected ${JSON.stringify(expectedData)} found ${JSON.stringify(data)}`);
   }
 
   // If data is not an object/array then match the values
   if (!isObj(data)) {
-    return (data === expectedData);
+    if (data !== expectedData) {
+      throw new Error(`Expected ${JSON.stringify(expectedData)} found ${JSON.stringify(data)}`);
+    }
+
+    return true;
   }
 
   // If data is empty and expectedData is not empty then throw an error
@@ -22,25 +26,20 @@ const deepEqSkip = function(data, expectedData, skipKeys = []) {
   if (!isDataEmpty(data) && isDataEmpty(expectedData)) {
     throw new Error(`Expected ${JSON.stringify(expectedData)} found ${JSON.stringify(data)}`);
   }
-  
-  // Validate whole object recursively
-  try {
-    for (let key in data) {
-      if (skipKeys.indexOf(key) === -1) {
-        if (!deepEqSkip(data[key], expectedData[key], skipKeys)) {
-          return false;
-        }
-      }
+
+  Object.getOwnPropertyNames(data).forEach(function (key) {
+    if (skipKeys.indexOf(key) !== -1) {
+      return;
     }
-    return true;
-  } catch (e) {
-    console.log(e);
-    return false;
-  }
+
+    deepEqSkip(data[key], expectedData[key], skipKeys);
+  });
+
+  return true;
 };
 
-const isDataEmpty = function(data) {
-  if(
+const isDataEmpty = function (data) {
+  if (
     Array.isArray(data) && !data.length ||
     isObj(data) && !Object.getOwnPropertyNames(data).length
   ) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -8,7 +8,13 @@ const INPUT_JSON = {
   'repository': {
     'url': 'https://github.com/arshadkazmi42/deep-eq-skip',
     'language': 'js'
-  }
+  },
+  'keywords': [
+    'deep-equal',
+    'deep-eq'
+  ],
+  'version': 1,
+  'private': false
 };
 
 const EXPECTED_JSON = {
@@ -17,7 +23,13 @@ const EXPECTED_JSON = {
   'repository': {
     'url': 'https://github.com/arshadkazmi42/deep-equal-skip',
     'language': 'js'
-  }
+  },
+  'keywords': [
+    'deep-equal',
+    'deep-eq'
+  ],
+  'version': 1,
+  'private': false
 };
 
 
@@ -27,20 +39,20 @@ describe('validates nested jsons', () => {
     expect(isEqual).to.equal(true);
   });
   it('should not be equal json', () => {
-    const isEqual = deepEqSkip(INPUT_JSON, EXPECTED_JSON, []);
-    expect(isEqual).to.equal(false);
+    const fn = deepEqSkip.bind(null, INPUT_JSON, EXPECTED_JSON, []);
+    expect(fn).to.throw(Error, 'Expected "deep-equal-skip" found "deep-eq-skip"');
   });
   it('should be equal json arrays', () => {
     const isEqual = deepEqSkip([INPUT_JSON, INPUT_JSON], [EXPECTED_JSON, EXPECTED_JSON], ['name', 'url']);
     expect(isEqual).to.equal(true);
   });
   it('should not be equal json arrays', () => {
-    const isEqual = deepEqSkip([INPUT_JSON, INPUT_JSON], [EXPECTED_JSON, EXPECTED_JSON], []);
-    expect(isEqual).to.equal(false);
+    const fn = deepEqSkip.bind(null, [INPUT_JSON, INPUT_JSON], [EXPECTED_JSON, EXPECTED_JSON], []);
+    expect(fn).to.throw(Error, 'Expected "deep-equal-skip" found "deep-eq-skip"');
   });
   it('should not be equal object and array', () => {
-    const isEqual = deepEqSkip([{'name': '1'}], {'name': '1'}, []);
-    expect(isEqual).to.equal(false);
+    const fn = deepEqSkip.bind(null, [{ 'name': '1' }], { 'name': '1' }, []);
+    expect(fn).to.throw(Error, 'Expected undefined found {"name":"1"}');
   });
 });
 
@@ -73,7 +85,11 @@ describe('validates flat data', () => {
     expect(isEqual).to.equal(true);
   });
   it('should not be equal strings', () => {
-    const isEqual = deepEqSkip('deep-eq-skip', 'deep-equal-skip');
-    expect(isEqual).to.equal(false);
+    const fn = deepEqSkip.bind(null, 'deep-eq-skip', 'deep-equal-skip');
+    expect(fn).to.throw(Error, 'Expected "deep-equal-skip" found "deep-eq-skip"');
+  });
+  it('should not be equal string and number', () => {
+    const fn = deepEqSkip.bind(null, '1', 1);
+    expect(fn).to.throw(Error, 'Expected 1 found "1"');
   });
 });


### PR DESCRIPTION
Hi @arshadkazmi42 ,
deepEqSkip should now throw an error with details when the key is not matched.
Let me know your thoughts